### PR TITLE
Fixed NonHierarchicalDistanceBasedAlgorithm

### DIFF
--- a/Clustering/Algorithms/GQuadItem.m
+++ b/Clustering/Algorithms/GQuadItem.m
@@ -34,4 +34,25 @@
     return [[NSSet alloc] initWithObjects:item, nil];
 }
 
+- (BOOL)isEqualToQuadItem:(GQuadItem *)other {
+    return [item isEqual:other->item]
+            && point.x == other->point.x
+            && point.y == other->point.y;
+}
+
+#pragma mark - NSObject
+
+- (BOOL)isEqual:(id)other {
+    if (other == self)
+        return YES;
+    if (!other || ![[other class] isEqual:[self class]])
+        return NO;
+
+    return [self isEqualToQuadItem:other];
+}
+
+- (NSUInteger)hash {
+    return [item hash];
+}
+
 @end

--- a/Clustering/Algorithms/NonHierarchicalDistanceBasedAlgorithm.m
+++ b/Clustering/Algorithms/NonHierarchicalDistanceBasedAlgorithm.m
@@ -61,7 +61,8 @@ int MAX_DISTANCE_AT_ZOOM = 10000;
                 }
                 
                 // Move item to the closer cluster.
-                [itemToCluster removeObjectForKey:[itemToCluster objectForKey:clusterItem]];
+                GStaticCluster *oldCluster = [itemToCluster objectForKey:clusterItem];
+                [oldCluster remove:clusterItem];
             }
             [distanceToCluster setObject:[NSNumber numberWithDouble:distance] forKey:clusterItem];
             [cluster add:clusterItem];


### PR DESCRIPTION
In some cases it counted one item in several clusters
There were two problems:
1) Typo in NonHierarchicalDistanceBasedAlgorithm.m
2) GQuadItem couldn't be used as NSDictionary key (had to override `-isEqual:` and `-hash` methods)
Original discussion: https://github.com/googlemaps/google-maps-ios-utils/issues/2
