### PR TITLE
 fix for crash on large number set as raised here  -> https://github.com/DDRBoxman/google-maps-ios-utils/issues/14

### DIFF
--- a/Clustering/Algorithms/GClusterAlgorithm.h
+++ b/Clustering/Algorithms/GClusterAlgorithm.h
@@ -6,7 +6,11 @@
 - (void)addItem:(id <GClusterItem>) item;
 - (void)removeItems;
 - (void)removeItemsNotInRectangle:(CGRect)rect;
+- (void)hideItemsNotInBounds: (GMSCoordinateBounds *)bounds;
 
+- (void)removeItem:(id <GClusterItem>) item;
+- (void)removeClusterItemsInSet:(NSSet *)set;
+- (BOOL)containsItem:(id <GClusterItem>) item;
 - (NSSet*)getClusters:(float)zoom;
 
 @end

--- a/Clustering/Algorithms/GQuadItem.h
+++ b/Clustering/Algorithms/GQuadItem.h
@@ -7,6 +7,7 @@
 @interface GQuadItem : NSObject <GCluster, GQTPointQuadTreeItem, NSCopying> 
 
 - (id)initWithItem:(id <GClusterItem>)item;
+- (id <GClusterItem>)item;
 
 @property(nonatomic, assign) CLLocationCoordinate2D position;
 

--- a/Clustering/Algorithms/GQuadItem.m
+++ b/Clustering/Algorithms/GQuadItem.m
@@ -7,6 +7,10 @@
     CLLocationCoordinate2D _position;
 }
 
+- (id)item{
+    return _item;
+}
+
 - (id)initWithItem:(id <GClusterItem>)clusterItem {
     if (self = [super init]) {
         SphericalMercatorProjection *projection = [[SphericalMercatorProjection alloc] initWithWorldWidth:1];

--- a/Clustering/Algorithms/NonHierarchicalDistanceBasedAlgorithm.h
+++ b/Clustering/Algorithms/NonHierarchicalDistanceBasedAlgorithm.h
@@ -5,7 +5,7 @@
 @interface NonHierarchicalDistanceBasedAlgorithm : NSObject<GClusterAlgorithm> 
 
 @property (nonatomic, strong) NSMutableArray *items;
-
+- (void)removeItem:(id <GClusterItem>) item;
 - (id)initWithMaxDistanceAtZoom:(NSInteger)maxDistanceAtZoom;
 
 @end

--- a/Clustering/Algorithms/NonHierarchicalDistanceBasedAlgorithm.m
+++ b/Clustering/Algorithms/NonHierarchicalDistanceBasedAlgorithm.m
@@ -29,6 +29,33 @@
     [_quadTree add:quadItem];
 }
 
+- (void)removeItem:(id <GClusterItem>) item{
+    NSSet *set = [NSSet setWithObject:item];
+    [self removeClusterItemsInSet:set];
+}
+- (void)removeClusterItemsInSet:(NSSet *)set {
+    NSMutableArray *toRemove = [NSMutableArray array];
+    [_items enumerateObjectsUsingBlock:^(GQuadItem *quadItem, NSUInteger idx, BOOL *stop) {
+        if ([set containsObject:quadItem.item]) {
+            [toRemove addObject:quadItem];
+        }
+    }];
+    [_items removeObjectsInArray:toRemove];
+    [toRemove enumerateObjectsUsingBlock:^(GQuadItem *quadItem, NSUInteger idx, BOOL *stop) {
+        [_quadTree remove:quadItem];
+    }];
+}
+-(BOOL)containsItem:(id <GClusterItem>) item{
+    __block BOOL bFound = NO;
+    [_items enumerateObjectsUsingBlock:^(GQuadItem *quadItem, NSUInteger idx, BOOL *stop) {
+        if(quadItem.item == item){
+            bFound =  YES;
+            *stop = YES;
+        }
+    }];
+    return bFound;
+}
+
 - (void)removeItems
 {
   [_items removeAllObjects];
@@ -48,6 +75,17 @@
         }
     
     _items = newItems;
+}
+
+- (void)hideItemsNotInBounds:(GMSCoordinateBounds*)bounds
+{
+    for (GQuadItem *item in _items){
+        if (![bounds containsCoordinate:item.position ]) {
+            item.hidden = YES;
+        }else{
+               item.hidden = NO;
+        }
+    }
 }
 
 - (NSSet*)getClusters:(float)zoom {

--- a/Clustering/GClusterManager.h
+++ b/Clustering/GClusterManager.h
@@ -15,7 +15,10 @@
 - (void)addItem:(id <GClusterItem>) item;
 - (void)removeItems;
 - (void)removeItemsNotInRectangle:(CGRect)rect;
+- (void)hideItemsNotInVisibleBounds;
 
+- (void)removeItem:(id <GClusterItem>) item;
+- (BOOL)containsItem:(id <GClusterItem>) item;
 - (void)cluster;
 
 //convenience

--- a/Clustering/GClusterManager.m
+++ b/Clustering/GClusterManager.m
@@ -24,12 +24,25 @@
     [_clusterAlgorithm addItem:item];
 }
 
+- (void)removeItem:(id <GClusterItem>) item {
+    [_clusterAlgorithm removeItem:item];
+}
+
+-(BOOL)containsItem:(id<GClusterItem>)item{
+    return [_clusterAlgorithm containsItem:item];
+}
+
 - (void)removeItems {
   [_clusterAlgorithm removeItems];
 }
 
 - (void)removeItemsNotInRectangle:(CGRect)rect {
     [_clusterAlgorithm removeItemsNotInRectangle:rect];
+}
+- (void)hideItemsNotInVisibleBounds{
+    GMSCoordinateBounds *bounds = [[GMSCoordinateBounds alloc]initWithRegion:self.mapView.projection.visibleRegion];
+      [_clusterAlgorithm hideItemsNotInBounds:bounds];
+    [self cluster];
 }
 
 - (void)cluster {

--- a/example/Google Maps iOS Example/Google Maps iOS Example/ClusterMapViewController.m
+++ b/example/Google Maps iOS Example/Google Maps iOS Example/ClusterMapViewController.m
@@ -15,6 +15,8 @@
 @implementation ClusterMapViewController {
     GMSMapView *mapView_;
     GClusterManager *clusterManager_;
+    NSMutableArray *spots;
+    NSMutableArray *markers;
 }
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
@@ -39,6 +41,8 @@
     mapView_.settings.myLocationButton = YES;
     mapView_.settings.compassButton = YES;
     self.view = mapView_;
+    spots = [NSMutableArray array];
+    markers = [NSMutableArray array];
     
     clusterManager_ = [GClusterManager managerWithMapView:mapView_
                                                algorithm:[[NonHierarchicalDistanceBasedAlgorithm alloc] init]
@@ -46,14 +50,35 @@
 
     [mapView_ setDelegate:clusterManager_];
     
-    for (int i=0; i<12; i++) {
-        Spot* spot = [self generateSpot];
+    for (int i=0; i<12000; i++) {
+        Spot* spot = [self generateSpot]; //auto add to markers
+        [spots addObject:spot];
         [clusterManager_ addItem:spot];
     }
-    
+
     [clusterManager_ cluster];
     [clusterManager_ setDelegate:self];
 }
+
+
+
+
+
+
+- (void)mapView:(GMSMapView *)mapView_ didChangeCameraPosition:(GMSCameraPosition *)position {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                             selector:@selector(updateMapResults) object:nil];
+    [self performSelector:@selector(updateMapResults) withObject:nil afterDelay:0.3];
+}
+//
+- (void)updateMapResults {
+    [self addOrRemovePinsNotOnScreen];
+}
+
+- (void)addOrRemovePinsNotOnScreen {
+    [clusterManager_ hideItemsNotInVisibleBounds];
+}
+
 
 - (BOOL)mapView:(GMSMapView *)mapView didTapMarker:(GMSMarker *)marker {
     [[[UIAlertView alloc] initWithTitle:@"DidTapMarker" message:marker.title delegate:self cancelButtonTitle:@"OK" otherButtonTitles:nil] show];
@@ -77,6 +102,7 @@
     Spot* spot = [[Spot alloc] init];
     spot.location = marker.position;
     spot.marker = marker;
+    [markers addObject:marker];
     return spot;
 }
 

--- a/example/Google Maps iOS Example/Google Maps iOS Example/ClusterMapViewController.m
+++ b/example/Google Maps iOS Example/Google Maps iOS Example/ClusterMapViewController.m
@@ -72,10 +72,6 @@
 }
 //
 - (void)updateMapResults {
-    [self addOrRemovePinsNotOnScreen];
-}
-
-- (void)addOrRemovePinsNotOnScreen {
     [clusterManager_ hideItemsNotInVisibleBounds];
 }
 


### PR DESCRIPTION
https://github.com/DDRBoxman/google-maps-ios-utils/issues/14

 [clusterManager_ hideItemsNotInVisibleBounds];

exposed ability to remove items and test if cluster contains item.

Or optionally - you can just cherry pick the hideItemsNotInVisibleBounds method
